### PR TITLE
Make the Composer output folded and verbose

### DIFF
--- a/gh-action/entrypoint.sh
+++ b/gh-action/entrypoint.sh
@@ -7,7 +7,10 @@ git remote remove bc_origin_https  >/dev/null 2>&1 || true
 git remote add bc_origin_https $REPO
 
 git fetch bc_origin_https --tags || true
-composer install --no-scripts --no-progress --quiet
+COMPOSER_COMMAND="composer install --no-scripts --no-progress"
+echo "::group::$COMPOSER_COMMAND"
+$COMPOSER_COMMAND
+echo "::endgroup::"
 /composer/vendor/bin/roave-backward-compatibility-check --version
 /composer/vendor/bin/roave-backward-compatibility-check $*
 


### PR DESCRIPTION
The special syntax at use here allows to fold the output, which makes it
more reasonable to have it verbose, which in turn should make issues
easier to troubleshoot.

If this looks familiar, that's because I contributed something similar at https://github.com/OskarStark/phpstan-ga/pull/23