### PR TITLE
Build new major version

### DIFF
--- a/6.x/Dockerfile
+++ b/6.x/Dockerfile
@@ -1,0 +1,8 @@
+FROM nyholm/roave-bc-check:base
+MAINTAINER Tobias Nyholm <tobias.nyholm@gmail.com>
+
+ENV BC_CHECK_VERSION 6.x
+
+RUN composer global require --no-update "roave/backward-compatibility-check:^6.0" \
+    && composer global update \
+    && composer global show | grep backward-compatibility-check

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSIONS := 1.x 2.x 3.x 4.x 5.x stable latest
+VERSIONS := 6.x stable latest
 BUILD_ALL_VERSIONS := $(addprefix build-, $(VERSIONS))
 TEST_ALL_VERSIONS := $(addprefix test-, $(VERSIONS))
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The image is based on [Alpine Linux](https://alpinelinux.org/) and built daily.
 
 - `latest` [(latest/Dockerfile)](latest/Dockerfile)
 - `stable` [(stable/Dockerfile)](stable/Dockerfile)
+- `6.x` [(6.x/Dockerfile)](6.x/Dockerfile)
 - `5.x` [(5.x/Dockerfile)](5.x/Dockerfile)
 - `4.x` [(4.x/Dockerfile)](4.x/Dockerfile)
 - `3.x` [(3.x/Dockerfile)](3.x/Dockerfile)
@@ -28,7 +29,7 @@ docker pull nyholm/roave-bc-check
 Alternatively, pull a specific version:
 
 ```
-docker pull nyholm/roave-bc-check:5.x
+docker pull nyholm/roave-bc-check:6.x
 ```
 
 ### Usage

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-alpine
+FROM php:8.1-alpine
 MAINTAINER Tobias Nyholm <tobias.nyholm@gmail.com>
 
 ENV COMPOSER_HOME /composer

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -1,11 +1,11 @@
 FROM nyholm/roave-bc-check:base
 MAINTAINER Tobias Nyholm <tobias.nyholm@gmail.com>
 
-ENV BC_CHECK_VERSION dev-master
+ENV BC_CHECK_VERSION 6.1.x
 
 RUN composer global config minimum-stability dev \
     && composer global config prefer-stable true
 
-RUN composer global require --no-update "roave/backward-compatibility-check:dev-master" \
+RUN composer global require --no-update "roave/backward-compatibility-check:6.1.x-dev" \
     && composer global update \
     && composer global show | grep backward-compatibility-check


### PR DESCRIPTION
Incidentally, this drops support for 1.x through 5.x, which would require building with a PHP 7 image.